### PR TITLE
update setCreditCard to use bill_zip instead of entire billAddress

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -85,12 +85,7 @@
         card_number: creditCard.card_number,
         card_cvc: creditCard.card_cvc,
         card_expiry: creditCard.formatExpirationDate(),
-        bill_addr: creditCard.billAddress.addr,
-        bill_addr2: creditCard.billAddress.addr2,
-        bill_city: creditCard.billAddress.city,
-        bill_state: creditCard.billAddress.state,
-        bill_zip: creditCard.billAddress.zip,
-        phone: creditCard.billAddress.phone,
+        bill_zip: creditCard.bill_zip,
         CustomerId: user.email
       }
       


### PR DESCRIPTION
I ran into a problem when I updated deliveratorjs where I had to create a creditCard object using only bill_zip, which is great, but setCreditCard in user.js was still trying to send the entire nested billAddress. Let me know if I should do this a different way. Just trying to get more into contributing stuff lately :)